### PR TITLE
Avoids misleading IFs

### DIFF
--- a/packages/eslint-config-accurapp/index.js
+++ b/packages/eslint-config-accurapp/index.js
@@ -58,6 +58,7 @@ module.exports = {
   rules: Object.assign(standardJSRulesWarn, {
     // WARNINGS
     'comma-dangle': [1, 'always-multiline'], // No risks, beacuse it will be transpiled
+    'curly': [2, 'always'],
     'space-before-function-paren': [1, { anonymous: 'always', named: 'never' }],
     'key-spacing': [1, { beforeColon: false, afterColon: true, mode: 'minimum' }],
     'object-curly-spacing': [1, 'always'],


### PR DESCRIPTION
Single line IF statement can be misleading.

See https://eslint.org/docs/rules/curly:

> [..] it is considered by many to be best practice to never omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity.